### PR TITLE
Anonymizing Dashboard Data.

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -117,10 +117,27 @@ public class AppProperties {
 	private Integer executor_queue_capacity = 100;
 	private String executor_thread_name_prefix = "AsyncThread-";
 	private String dev_user_role = "dev";
-
+	private Double maxNoisePercentage = 30.0;
+	private Double minNoisePercentage = 10.0;
 	private List<String> organization_ids_for_caching = null;
 
 	private List<String> envs_for_caching = null;
+
+	public Double getMinNoisePercentage() {
+		return minNoisePercentage;
+	}
+
+	public void setMinNoisePercentage(Double minNoisePercentage) {
+		this.minNoisePercentage = minNoisePercentage;
+	}
+
+	public Double getMaxNoisePercentage() {
+		return maxNoisePercentage;
+	}
+
+	public void setMaxNoisePercentage(Double maxNoisePercentage) {
+		this.maxNoisePercentage = maxNoisePercentage;
+	}
 
 	public void setAws_access_key(String aws_access_key) {
 		this.aws_access_key = aws_access_key;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/Anonymizer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/Anonymizer.java
@@ -1,0 +1,8 @@
+package ca.uhn.fhir.jpa.starter.anonymization;
+
+public interface Anonymizer {
+
+	Boolean isAnonymized(String token);
+
+	Double anonymize(Double value, Double minPercent, Double maxPercent);
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/AnonymizerContext.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/AnonymizerContext.java
@@ -1,0 +1,15 @@
+package ca.uhn.fhir.jpa.starter.anonymization;
+
+public class AnonymizerContext {
+	DashboardDataAnonymizer dashboardDataAnonymizer = new DashboardDataAnonymizer();
+
+	public Boolean isAnonymized(String token){
+		return dashboardDataAnonymizer.isAnonymized(token);
+	}
+
+	public Double anonymize(Boolean isAnonymizationEnabled, Double value,Double minPercent,Double maxPercent){
+		if (isAnonymizationEnabled)
+			return dashboardDataAnonymizer.anonymize(value, minPercent, maxPercent);
+		return value;
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/DashboardDataAnonymizer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/DashboardDataAnonymizer.java
@@ -1,0 +1,24 @@
+package ca.uhn.fhir.jpa.starter.anonymization;
+
+import com.iprd.fhir.utils.Validation;
+
+public class DashboardDataAnonymizer implements Anonymizer  {
+	@Override
+	public Boolean isAnonymized(String token) {
+		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
+		return isAnonymizationEnabled != null;
+	}
+
+	@Override
+	public Double anonymize(Double value, Double minPercent, Double maxPercent) {
+		try {
+			double noisePercent = Randomizer.getRandom(minPercent, maxPercent);
+			double noiseValue = (value * noisePercent / 100);
+			double anonymizedValue = value + noiseValue;
+			return (double) Math.round(anonymizedValue);
+		} catch (ArithmeticException e) {
+			e.printStackTrace();
+			return value;
+		}
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/DashboardDataAnonymizer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/DashboardDataAnonymizer.java
@@ -6,7 +6,10 @@ public class DashboardDataAnonymizer implements Anonymizer  {
 	@Override
 	public Boolean isAnonymized(String token) {
 		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
-		return isAnonymizationEnabled != null;
+		if (isAnonymizationEnabled != null)
+			return isAnonymizationEnabled;
+		else
+			return false;
 	}
 
 	@Override

--- a/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/ISANONYMIZED.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/ISANONYMIZED.java
@@ -1,0 +1,6 @@
+package ca.uhn.fhir.jpa.starter.anonymization;
+
+public enum ISANONYMIZED {
+	YES,
+	NO
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/Randomizer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/anonymization/Randomizer.java
@@ -1,0 +1,24 @@
+package ca.uhn.fhir.jpa.starter.anonymization;
+
+import java.util.Random;
+
+public class Randomizer {
+
+	static Double getRandom(Double min, Double max) {
+		Random random = new Random();
+		double randomValue = random.nextDouble();
+
+		// Randomly decide whether to add or subtract
+		if (random.nextBoolean()) {
+			// Try to subtract
+			double result = min + (max - min) * randomValue - randomValue * (max - min);
+			// Ensure the result is not negative
+			if (result >= 0) {
+				return result;
+			}
+		}
+
+		// If subtraction is not possible or not chosen, add
+		return min + (max - min) * randomValue + randomValue * (max - min);
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/controller/DashboardController.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/controller/DashboardController.java
@@ -169,6 +169,9 @@ public class DashboardController {
  		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		ReportType type = ReportType.valueOf(allFilters.get("type"));
+		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
+		if (isAnonymizationEnabled == null)
+			isAnonymizationEnabled = false;
 		allFilters.remove("from");
 		allFilters.remove("to");
 		allFilters.remove("type");
@@ -180,7 +183,7 @@ public class DashboardController {
 		}
 		LinkedHashMap<String, String> filters = new LinkedHashMap<>();
 		filters.putAll(allFilters);
-		return helperService.getDataByPractitionerRoleId(practitionerRoleId, startDate, endDate, type, filters, env);
+		return helperService.getDataByPractitionerRoleId(practitionerRoleId, startDate, endDate, type, filters, env, isAnonymizationEnabled);
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/linechart")

--- a/src/main/java/ca/uhn/fhir/jpa/starter/controller/DashboardController.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/controller/DashboardController.java
@@ -50,9 +50,13 @@ public class DashboardController {
 
 		@RequestMapping(method = RequestMethod.GET, value = "/details")
 	public ResponseEntity<?> getDetails(
+		@RequestHeader(name = "Authorization") String token,
 		@RequestParam("env") String env,
 		@RequestParam Map<String, String> allFilters
 	) throws SQLException, IOException {
+		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
+		if (isAnonymizationEnabled == null)
+			isAnonymizationEnabled = false;
 		String organizationId = allFilters.get("lga");
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
@@ -66,8 +70,8 @@ public class DashboardController {
 
 		Map<String,String> categoryWithHashCodes = helperService.processCategories(organizationId, startDate, endDate, env, filters,true);
 
-		if (helperService.getAsyncData(categoryWithHashCodes).getBody() == "Searching in Progress") return ResponseEntity.status(202).build();
-		return ResponseEntity.ok(helperService.getAsyncData(categoryWithHashCodes));
+		if (helperService.getAsyncData(categoryWithHashCodes, isAnonymizationEnabled).getBody() == "Searching in Progress") return ResponseEntity.status(202).build();
+		return ResponseEntity.ok(helperService.getAsyncData(categoryWithHashCodes, isAnonymizationEnabled));
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/lastSyncTime")
@@ -189,6 +193,9 @@ public class DashboardController {
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		ReportType type = ReportType.valueOf(allFilters.get("type"));
+		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
+		if (isAnonymizationEnabled == null)
+			isAnonymizationEnabled = false;
 		allFilters.remove("from");
 		allFilters.remove("to");
 		allFilters.remove("type");
@@ -200,7 +207,7 @@ public class DashboardController {
 		}
 		LinkedHashMap<String, String> filters = new LinkedHashMap<>();
 		filters.putAll(allFilters);
-		return helperService.getLineChartByPractitionerRoleId(startDate,endDate,type,filters,env,lga);
+		return helperService.getLineChartByPractitionerRoleId(startDate,endDate,type,filters,env,lga,isAnonymizationEnabled);
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/pieChartData")
@@ -210,6 +217,9 @@ public class DashboardController {
 		@RequestParam("lga") String lga,
 		@RequestParam Map<String, String> allFilters
 	){
+		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
+		if (isAnonymizationEnabled == null)
+			isAnonymizationEnabled = false;
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		allFilters.remove("from");
@@ -221,7 +231,7 @@ public class DashboardController {
 		LinkedHashMap<String, String> filters = new LinkedHashMap<>();
 		filters.putAll(allFilters);
 
-		return helperService.getPieChartDataByPractitionerRoleId(startDate, endDate,filters,env,lga);
+		return helperService.getPieChartDataByPractitionerRoleId(startDate, endDate,filters,env,lga,isAnonymizationEnabled);
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/tabularData")
@@ -231,6 +241,9 @@ public class DashboardController {
 		@RequestParam("lga") String lga,
 		@RequestParam Map<String, String> allFilters
 	) {
+		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
+		if (isAnonymizationEnabled == null)
+			isAnonymizationEnabled = false;
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		allFilters.remove("from");
@@ -243,7 +256,7 @@ public class DashboardController {
 			return ResponseEntity.ok("Error : Practitioner Role Id not found in token");
 		}
 		LinkedHashMap<String, String> filters = new LinkedHashMap<>(allFilters);
-		return helperService.getTabularDataByPractitionerRoleId(startDate, endDate, filters,env,lga);
+		return helperService.getTabularDataByPractitionerRoleId(startDate, endDate, filters,env,lga,isAnonymizationEnabled);
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/refreshMapToOrgId")
@@ -262,6 +275,9 @@ public class DashboardController {
 		@RequestParam("lga") String lga,
 		@RequestParam Map<String, String> allFilters
 	) {
+		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
+		if (isAnonymizationEnabled == null)
+			isAnonymizationEnabled = false;
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		allFilters.remove("from");
@@ -275,7 +291,7 @@ public class DashboardController {
 		}
 		LinkedHashMap<String, String> filters = new LinkedHashMap<>();
 		filters.putAll(allFilters);
-		return helperService.getBarChartData(startDate, endDate,filters,env,lga);
+		return helperService.getBarChartData(startDate, endDate,filters,env,lga,isAnonymizationEnabled);
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/analytics")
@@ -315,7 +331,10 @@ public class DashboardController {
 		@RequestParam("from") String from,
 		@RequestParam("to") String to
 	) {
-		return helperService.getEncounterForMap(orgId, from, to);
+		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
+		if (isAnonymizationEnabled == null)
+			isAnonymizationEnabled = false;
+		return helperService.getEncounterForMap(orgId, from, to, isAnonymizationEnabled);
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/facilitySummaryData")
@@ -325,6 +344,9 @@ public class DashboardController {
 		@RequestParam("lga") String lga,
 		@RequestParam Map<String, String> allFilters
 	) {
+		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
+		if (isAnonymizationEnabled == null)
+			isAnonymizationEnabled = false;
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		ReportType type = ReportType.valueOf(allFilters.get("type"));
@@ -338,7 +360,7 @@ public class DashboardController {
 			return ResponseEntity.ok("Error : Practitioner Role Id not found in token");
 		}
 		LinkedHashMap<String, String> filters = new LinkedHashMap<>(allFilters);
-		return helperService.processDataForReport(startDate, endDate,type, filters, env, lga);
+		return helperService.processDataForReport(startDate, endDate,type, filters, env, lga, isAnonymizationEnabled);
 	}
 
 	@RequestMapping(method = RequestMethod.GET, value = "/cacheDashboardDataSequential")

--- a/src/main/java/ca/uhn/fhir/jpa/starter/controller/DashboardController.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/controller/DashboardController.java
@@ -3,16 +3,14 @@ package ca.uhn.fhir.jpa.starter.controller;
 import android.util.Pair;
 import ca.uhn.fhir.jpa.starter.ConfigDefinitionTypes;
 import ca.uhn.fhir.jpa.starter.DashboardEnvironmentConfig;
+import ca.uhn.fhir.jpa.starter.anonymization.AnonymizerContext;
 import ca.uhn.fhir.jpa.starter.model.AnalyticItem;
-import ca.uhn.fhir.jpa.starter.model.ApiAsyncTaskEntity;
 import ca.uhn.fhir.jpa.starter.model.ReportType;
 import ca.uhn.fhir.jpa.starter.service.BigQueryService;
 import ca.uhn.fhir.jpa.starter.service.HelperService;
 import ca.uhn.fhir.jpa.starter.service.NotificationDataSource;
 import com.iprd.fhir.utils.Validation;
 import com.iprd.report.OrgItem;
-import com.iprd.report.model.definition.ANCDailySummaryConfig;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hl7.fhir.r4.model.Organization;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +21,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
 import java.util.*;
 
 @CrossOrigin(origins = {"http://localhost:3000/", "http://testhost.dashboard:3000/", "https://oclink.io/", "https://opencampaignlink.org/"}, maxAge = 3600, allowCredentials = "true")
@@ -31,6 +28,7 @@ import java.util.*;
 @RequestMapping("/iprd/web")
 public class DashboardController {
 	NotificationDataSource datasource = NotificationDataSource.getInstance();
+	AnonymizerContext anonymizerContext = new AnonymizerContext();
 	@Autowired
 	HelperService helperService;
 	@Autowired
@@ -54,9 +52,7 @@ public class DashboardController {
 		@RequestParam("env") String env,
 		@RequestParam Map<String, String> allFilters
 	) throws SQLException, IOException {
-		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
-		if (isAnonymizationEnabled == null)
-			isAnonymizationEnabled = false;
+		Boolean isAnonymizationEnabled = anonymizerContext.isAnonymized(token);
 		String organizationId = allFilters.get("lga");
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
@@ -169,9 +165,7 @@ public class DashboardController {
  		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		ReportType type = ReportType.valueOf(allFilters.get("type"));
-		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
-		if (isAnonymizationEnabled == null)
-			isAnonymizationEnabled = false;
+		Boolean isAnonymizationEnabled = anonymizerContext.isAnonymized(token);
 		allFilters.remove("from");
 		allFilters.remove("to");
 		allFilters.remove("type");
@@ -196,9 +190,7 @@ public class DashboardController {
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		ReportType type = ReportType.valueOf(allFilters.get("type"));
-		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
-		if (isAnonymizationEnabled == null)
-			isAnonymizationEnabled = false;
+		Boolean isAnonymizationEnabled = anonymizerContext.isAnonymized(token);
 		allFilters.remove("from");
 		allFilters.remove("to");
 		allFilters.remove("type");
@@ -220,9 +212,7 @@ public class DashboardController {
 		@RequestParam("lga") String lga,
 		@RequestParam Map<String, String> allFilters
 	){
-		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
-		if (isAnonymizationEnabled == null)
-			isAnonymizationEnabled = false;
+		Boolean isAnonymizationEnabled = anonymizerContext.isAnonymized(token);
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		allFilters.remove("from");
@@ -244,9 +234,7 @@ public class DashboardController {
 		@RequestParam("lga") String lga,
 		@RequestParam Map<String, String> allFilters
 	) {
-		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
-		if (isAnonymizationEnabled == null)
-			isAnonymizationEnabled = false;
+		Boolean isAnonymizationEnabled = anonymizerContext.isAnonymized(token);
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		allFilters.remove("from");
@@ -278,9 +266,7 @@ public class DashboardController {
 		@RequestParam("lga") String lga,
 		@RequestParam Map<String, String> allFilters
 	) {
-		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
-		if (isAnonymizationEnabled == null)
-			isAnonymizationEnabled = false;
+		Boolean isAnonymizationEnabled = anonymizerContext.isAnonymized(token);
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		allFilters.remove("from");
@@ -334,9 +320,7 @@ public class DashboardController {
 		@RequestParam("from") String from,
 		@RequestParam("to") String to
 	) {
-		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
-		if (isAnonymizationEnabled == null)
-			isAnonymizationEnabled = false;
+		Boolean isAnonymizationEnabled = anonymizerContext.isAnonymized(token);
 		return helperService.getEncounterForMap(orgId, from, to, isAnonymizationEnabled);
 	}
 
@@ -347,9 +331,7 @@ public class DashboardController {
 		@RequestParam("lga") String lga,
 		@RequestParam Map<String, String> allFilters
 	) {
-		Boolean isAnonymizationEnabled = Validation.getJWTToken(token).getAnonymization();
-		if (isAnonymizationEnabled == null)
-			isAnonymizationEnabled = false;
+		Boolean isAnonymizationEnabled = anonymizerContext.isAnonymized(token);
 		String startDate = allFilters.get("from");
 		String endDate = allFilters.get("to");
 		ReportType type = ReportType.valueOf(allFilters.get("type"));

--- a/src/main/java/ca/uhn/fhir/jpa/starter/model/ApiAsyncTaskEntity.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/model/ApiAsyncTaskEntity.java
@@ -1,4 +1,5 @@
 package ca.uhn.fhir.jpa.starter.model;
+
 import javax.persistence.Column;
 
 import javax.persistence.*;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/model/ApiAsyncTaskEntity.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/model/ApiAsyncTaskEntity.java
@@ -35,13 +35,17 @@ public class ApiAsyncTaskEntity {
 	@Column(name = "lastUpdated", nullable = true)
 	private Date lastUpdated;
 
+	@Column(name = "isAnonymousEntry", nullable = true)
+	private String isAnonymousEntry;
+
 	public ApiAsyncTaskEntity() {}
-	public ApiAsyncTaskEntity(String uuid, String status, java.sql.Clob  summaryResult,java.sql.Clob dailyResult, Date lastUpdated) {
+	public ApiAsyncTaskEntity(String uuid, String status, java.sql.Clob  summaryResult,java.sql.Clob dailyResult, Date lastUpdated, String isAnonymousEntry) {
 		this.uuid = uuid;
 		this.status = status;
 		this.summaryResult = summaryResult;
 		this.dailyResult = dailyResult;
 		this.lastUpdated = lastUpdated;
+		this.isAnonymousEntry = isAnonymousEntry;
 	}
 	public Long getId() {
 		return id;
@@ -85,5 +89,13 @@ public class ApiAsyncTaskEntity {
 
 	public void setLastUpdated(Date lastUpdated) {
 		this.lastUpdated = lastUpdated;
+	}
+
+	public String getAnonymousEntry() {
+		return isAnonymousEntry;
+	}
+
+	public void setAnonymousEntry(String anonymousEntry) {
+		isAnonymousEntry = anonymousEntry;
 	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/model/JWTPayload.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/model/JWTPayload.java
@@ -27,8 +27,8 @@ public class JWTPayload {
 	private String given_name;
 	private String family_name;
 	private String email;
+	private Boolean anonymization;
 	private List<String> clientRoles = new ArrayList<>();;
-
 	public  List<String> getClientRoles() {
 		return clientRoles;
 	}
@@ -205,4 +205,11 @@ public class JWTPayload {
 		return this.practitioner_role_id;
 	}
 
+	public void setAnonymization(Boolean anonymization){
+		this.anonymization = anonymization;
+	}
+
+	public Boolean getAnonymization() {
+		return anonymization;
+	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/service/HelperService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/service/HelperService.java
@@ -1834,7 +1834,7 @@ public class HelperService {
 	}
 
 	public ResponseEntity<?> getDataByPractitionerRoleId(String practitionerRoleId, String startDate, String endDate,
-																		  ReportType type, LinkedHashMap<String, String> filters, String env) {
+																		  ReportType type, LinkedHashMap<String, String> filters, String env, Boolean isAnonymizationEnabled) {
 		notificationDataSource = NotificationDataSource.getInstance();
 		List<ScoreCardResponseItem> scoreCardResponseItems = new ArrayList<>();
 		List<String> facilities = new ArrayList<>();
@@ -1962,6 +1962,8 @@ public class HelperService {
 								if (TRANSFORM_SERVER_WITHOUT_ZERO.equals(transformServer)) {
 									value = calculateAverage(facility, orgIndicatorAverageResultWithoutZero, hashedId);
 								}
+								if (isAnonymizationEnabled)
+									value = Utils.anonymizedData(value, appProperties.getMinNoisePercentage(), appProperties.getMaxNoisePercentage());
 								scoreCardItems.add(new ScoreCardItem(orgHierarchyItem.getOrgId(), indicator.getId(),
 									value.toString(), startDate, endDate));
 							}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/service/HelperService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/service/HelperService.java
@@ -1024,15 +1024,17 @@ public class HelperService {
 			String dailyResultInString = convertClobToString(asyncRecord.getDailyResult());
 			String summaryResultInString = convertClobToString(asyncRecord.getSummaryResult());
 			if (!anonymousAsyncData.isEmpty() && isAnonymizationEnabled) {
-				String formattedDailyResultString = dailyResultInString.replace("]",",");
 				ApiAsyncTaskEntity anonymousAsyncRecord = anonymousAsyncData.get(0);
-				String anonymousDailyResultInString = convertClobToString(anonymousAsyncRecord.getDailyResult()).replace("[","");
-				dailyResultInString = formattedDailyResultString + anonymousDailyResultInString;
-				System.out.println(dailyResultInString);
+				String anonymousDailyResultInString = convertClobToString(anonymousAsyncRecord.getDailyResult());
+				String anonymousSummaryResultInString = convertClobToString(anonymousAsyncRecord.getSummaryResult());
+				List<Map<String, String>> anonymousDailyResult = mapper.readValue(anonymousDailyResultInString, new TypeReference<List<Map<String, String>>>() {
+				});
+				dataResult.add(new DataResultJava(item.getKey(), anonymousSummaryResultInString, anonymousDailyResult));
+			} else{
+				List<Map<String, String>> dailyResult = mapper.readValue(dailyResultInString, new TypeReference<List<Map<String, String>>>() {
+				});
+				dataResult.add(new DataResultJava(item.getKey(), summaryResultInString, dailyResult));
 			}
-			List<Map<String, String>> dailyResult = mapper.readValue(dailyResultInString, new TypeReference<List<Map<String, String>>>() {
-			});
-			dataResult.add(new DataResultJava(item.getKey(), summaryResultInString, dailyResult));
 		}
 		return ResponseEntity.ok(dataResult);
 	}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/service/NotificationDataSource.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/service/NotificationDataSource.java
@@ -396,8 +396,19 @@ public class NotificationDataSource {
 
 	public ArrayList<ApiAsyncTaskEntity> fetchStatus(String uuid) {
 		Session session = sf.openSession();
-		Query query = session.createQuery("FROM ApiAsyncTaskEntity WHERE uuid=:param1");
+		Query query = session.createQuery("FROM ApiAsyncTaskEntity WHERE uuid=:param1 AND isAnonymousEntry=:param2");
 		query.setParameter("param1", uuid);
+		query.setParameter("param2","no");
+		ArrayList<ApiAsyncTaskEntity> resultList = (ArrayList<ApiAsyncTaskEntity>) query.getResultList();
+		session.close();
+		return resultList;
+	}
+
+	public ArrayList<ApiAsyncTaskEntity> fetchAnonymousData(String dateRangeUuid) {
+		Session session = sf.openSession();
+		Query query = session.createQuery("FROM ApiAsyncTaskEntity WHERE uuid LIKE :param1 AND isAnonymousEntry=:param2");
+		query.setParameter("param2","yes");
+		query.setParameter("param1", dateRangeUuid);
 		ArrayList<ApiAsyncTaskEntity> resultList = (ArrayList<ApiAsyncTaskEntity>) query.getResultList();
 		session.close();
 		return resultList;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/service/NotificationDataSource.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/service/NotificationDataSource.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import ca.uhn.fhir.jpa.starter.anonymization.ISANONYMIZED;
 import ca.uhn.fhir.jpa.starter.model.*;
 import ca.uhn.fhir.jpa.starter.model.ComGenerator.MessageStatus;
 import com.iprd.fhir.utils.PatientIdentifierStatus;
@@ -398,7 +399,7 @@ public class NotificationDataSource {
 		Session session = sf.openSession();
 		Query query = session.createQuery("FROM ApiAsyncTaskEntity WHERE uuid=:param1 AND isAnonymousEntry=:param2");
 		query.setParameter("param1", uuid);
-		query.setParameter("param2","no");
+		query.setParameter("param2", ISANONYMIZED.NO.name());
 		ArrayList<ApiAsyncTaskEntity> resultList = (ArrayList<ApiAsyncTaskEntity>) query.getResultList();
 		session.close();
 		return resultList;
@@ -407,8 +408,8 @@ public class NotificationDataSource {
 	public ArrayList<ApiAsyncTaskEntity> fetchAnonymousData(String dateRangeUuid) {
 		Session session = sf.openSession();
 		Query query = session.createQuery("FROM ApiAsyncTaskEntity WHERE uuid LIKE :param1 AND isAnonymousEntry=:param2");
-		query.setParameter("param2","yes");
 		query.setParameter("param1", dateRangeUuid);
+		query.setParameter("param2",ISANONYMIZED.YES.name());
 		ArrayList<ApiAsyncTaskEntity> resultList = (ArrayList<ApiAsyncTaskEntity>) query.getResultList();
 		session.close();
 		return resultList;

--- a/src/main/java/com/iprd/fhir/utils/Utils.java
+++ b/src/main/java/com/iprd/fhir/utils/Utils.java
@@ -573,16 +573,4 @@ public class Utils {
 			.map(Date::toLocalDate)
 			.noneMatch(date -> date.equals(currentLocalDate));
 	}
-
-	public static Double anonymizedData(double actualValue, double minPercent, double maxPercent) {
-		double noisePercent = getRandomPercent(minPercent, maxPercent);
-		double noiseValue = (actualValue * noisePercent / 100);
-		double anonymizedValue = actualValue + noiseValue;
-		return (double) Math.round(anonymizedValue);
-	}
-
-	public static Double getRandomPercent(double min, double max){
-		Random random = new Random();
-		return min + (max - min) * random.nextDouble();
-	}
 }

--- a/src/main/java/com/iprd/fhir/utils/Utils.java
+++ b/src/main/java/com/iprd/fhir/utils/Utils.java
@@ -574,4 +574,15 @@ public class Utils {
 			.noneMatch(date -> date.equals(currentLocalDate));
 	}
 
+	public static Double anonymizedData(double actualValue, double minPercent, double maxPercent) {
+		double noisePercent = getRandomPercent(minPercent, maxPercent);
+		double noiseValue = (actualValue * noisePercent / 100);
+		double anonymizedValue = actualValue + noiseValue;
+		return (double) Math.round(anonymizedValue);
+	}
+
+	public static Double getRandomPercent(double min, double max){
+		Random random = new Random();
+		return min + (max - min) * random.nextDouble();
+	}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -70,6 +70,8 @@ tus-server:
    
 hapi:
    fhir:
+      minNoisePercentage: 20.0
+      maxNoisePercentage: 60.0
 #      hibernate.cache.use_structured_entries: false
       openapi_enabled: true
       fhir_version: R4

--- a/src/test/java/ca/uhn/fhir/jpa/starter/service/HelperServiceTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/service/HelperServiceTest.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.jpa.starter.AsyncConfiguration;
 import ca.uhn.fhir.jpa.starter.DashboardConfigContainer;
+import ca.uhn.fhir.jpa.starter.anonymization.ISANONYMIZED;
 import ca.uhn.fhir.jpa.starter.model.ApiAsyncTaskEntity;
 import ca.uhn.fhir.jpa.starter.model.CategoryItem;
 import ca.uhn.fhir.jpa.starter.model.PatientIdentifierEntity;
@@ -558,7 +559,7 @@ class HelperServiceTest {
 			createClob(""),
 			createClob(emptyList.toString()),
 			Date.valueOf(LocalDate.now()),
-			"no"
+			ISANONYMIZED.NO.name()
 		);
 		String dailyResultJsonString = new Gson().toJson(dailyResult);
 		ArrayList<ApiAsyncTaskEntity> apiAsyncTaskEntityList = new ArrayList<>();
@@ -944,14 +945,14 @@ class HelperServiceTest {
 		AppProperties appPropertiesMock =  new AppProperties();
 		appPropertiesMock.setFacility_batch_size(50);
 		Whitebox.setInternalState(helperServiceMock, appPropertiesMock);
-		doCallRealMethod().when(helperServiceMock).getDataByPractitionerRoleId(anyString(),anyString(),anyString(),any(),any(),anyString());
+		doCallRealMethod().when(helperServiceMock).getDataByPractitionerRoleId(anyString(),anyString(),anyString(),any(),any(),anyString(), false);
 		doCallRealMethod().when(helperServiceMock).getFacilitiesForOrganization(any(),anyList());
 		doCallRealMethod().when(helperServiceMock).calculateAverage(anyList(),anyList(),anyString());
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 		executor.initialize();
 		when(helperServiceMock.getAsyncExecutor(
 		)).thenReturn(executor);
-		ResponseEntity<?> output = helperServiceMock.getDataByPractitionerRoleId(practitionerRoleId,"2024-01-01","2024-01-07",type,filters,"V2");
+		ResponseEntity<?> output = helperServiceMock.getDataByPractitionerRoleId(practitionerRoleId,"2024-01-01","2024-01-07",type,filters,"V2", false);
 		List<ScoreCardResponseItem> scoreCardResponseItems  =  (List<ScoreCardResponseItem>) output.getBody();
 		assertEquals(HttpStatus.OK, output.getStatusCode());
 		assert scoreCardResponseItems != null;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/service/HelperServiceTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/service/HelperServiceTest.java
@@ -557,7 +557,8 @@ class HelperServiceTest {
 			"PROCESSING",
 			createClob(""),
 			createClob(emptyList.toString()),
-			Date.valueOf(LocalDate.now())
+			Date.valueOf(LocalDate.now()),
+			"no"
 		);
 		String dailyResultJsonString = new Gson().toJson(dailyResult);
 		ArrayList<ApiAsyncTaskEntity> apiAsyncTaskEntityList = new ArrayList<>();
@@ -800,8 +801,8 @@ class HelperServiceTest {
 		when(helperServiceMock.getCacheValueForDateRangeIndicatorAndMultipleOrgIdByReflection(anyString(),any(),any(),anyString(),anyList()
 		)).thenReturn(Double.valueOf("2.0"));
 		doNothing().when(helperServiceMock).performCachingIfNotPresentForBarChart(anyList(),anyList(),any(),any(),anyList());
-		doCallRealMethod().when(helperServiceMock).getBarChartData(anyString(),anyString(),any(),anyString(),anyString());
-		ResponseEntity<?> output = helperServiceMock.getBarChartData(testParameters.get("startDate"),testParameters.get("endDate"),filters,testParameters.get("env"),testParameters.get("lga"));
+		doCallRealMethod().when(helperServiceMock).getBarChartData(anyString(),anyString(),any(),anyString(),anyString(),false);
+		ResponseEntity<?> output = helperServiceMock.getBarChartData(testParameters.get("startDate"),testParameters.get("endDate"),filters,testParameters.get("env"),testParameters.get("lga"),false);
 		List<BarChartItemDataCollection> barChartItems =  (List<BarChartItemDataCollection>) output.getBody();
 		// Assertions for a successful scenario
 		assertEquals(HttpStatus.OK, output.getStatusCode());
@@ -822,29 +823,29 @@ class HelperServiceTest {
 		when(helperServiceMock.getCacheValueForDateRangeIndicatorAndMultipleOrgIdByReflection(anyString(),any(),any(),anyString(),anyList()
 		)).thenReturn(Double.valueOf("3.0"));
 		doNothing().when(helperServiceMock).performCachingForLineChartIfNotPresent(anyList(),anyList(),any(),any(),anyList());
-		doCallRealMethod().when(helperServiceMock).getLineChartByPractitionerRoleId(anyString(),anyString(),any(),any(),anyString(),anyString());
-		ResponseEntity<?> output = helperServiceMock.getLineChartByPractitionerRoleId(testParameters.get("startDate"),testParameters.get("endDate"), ReportType.valueOf("daily"),filters,testParameters.get("env"),testParameters.get("lga"));
+		doCallRealMethod().when(helperServiceMock).getLineChartByPractitionerRoleId(anyString(),anyString(),any(),any(),anyString(),anyString(),false);
+		ResponseEntity<?> output = helperServiceMock.getLineChartByPractitionerRoleId(testParameters.get("startDate"),testParameters.get("endDate"), ReportType.valueOf("daily"),filters,testParameters.get("env"),testParameters.get("lga"), false);
 		List<LineChartItemCollection> lineChartItems =  (List<LineChartItemCollection>) output.getBody();
 		assertEquals(HttpStatus.OK, output.getStatusCode());
 		assert lineChartItems != null;
 		assertEquals("3.0", lineChartItems.get(0).getValue().get(0).getValue());
 		when(helperServiceMock.getCacheValueForDateRangeIndicatorAndMultipleOrgIdByReflection(anyString(),any(),any(),anyString(),anyList()
 		)).thenReturn(Double.valueOf("4.0"));
-		ResponseEntity<?> weeklyOutput = helperServiceMock.getLineChartByPractitionerRoleId("2024-01-01","2024-01-07", ReportType.valueOf("weekly"),filters,testParameters.get("env"),testParameters.get("lga"));
+		ResponseEntity<?> weeklyOutput = helperServiceMock.getLineChartByPractitionerRoleId("2024-01-01","2024-01-07", ReportType.valueOf("weekly"),filters,testParameters.get("env"),testParameters.get("lga"),false);
 		List<LineChartItemCollection> lineChartItemsWeekly =  (List<LineChartItemCollection>) weeklyOutput.getBody();
 		assertEquals(HttpStatus.OK, weeklyOutput.getStatusCode());
 		assert lineChartItemsWeekly != null;
 		assertEquals("4.0", lineChartItemsWeekly.get(0).getValue().get(0).getValue());
 		when(helperServiceMock.getCacheValueForDateRangeIndicatorAndMultipleOrgIdByReflection(anyString(),any(),any(),anyString(),anyList()
 		)).thenReturn(Double.valueOf("6.0"));
-		ResponseEntity<?> monthlyOutput = helperServiceMock.getLineChartByPractitionerRoleId("2024-01-01","2024-01-07", ReportType.valueOf("monthly"),filters,testParameters.get("env"),testParameters.get("lga"));
+		ResponseEntity<?> monthlyOutput = helperServiceMock.getLineChartByPractitionerRoleId("2024-01-01","2024-01-07", ReportType.valueOf("monthly"),filters,testParameters.get("env"),testParameters.get("lga"),false);
 		List<LineChartItemCollection> lineChartItemsMonthly =  (List<LineChartItemCollection>) monthlyOutput.getBody();
 		assertEquals(HttpStatus.OK, monthlyOutput.getStatusCode());
 		assert lineChartItemsMonthly != null;
 		assertEquals("6.0", lineChartItemsMonthly.get(0).getValue().get(0).getValue());
 		when(helperServiceMock.getCacheValueForDateRangeIndicatorAndMultipleOrgIdByReflection(anyString(),any(),any(),anyString(),anyList()
 		)).thenReturn(Double.valueOf("26.0"));
-		ResponseEntity<?> quarterlyOutput = helperServiceMock.getLineChartByPractitionerRoleId("2024-01-01","2024-01-07", ReportType.valueOf("quarterly"),filters,testParameters.get("env"),testParameters.get("lga"));
+		ResponseEntity<?> quarterlyOutput = helperServiceMock.getLineChartByPractitionerRoleId("2024-01-01","2024-01-07", ReportType.valueOf("quarterly"),filters,testParameters.get("env"),testParameters.get("lga"),false);
 		List<LineChartItemCollection> lineChartItemsQuarterly =  (List<LineChartItemCollection>) quarterlyOutput.getBody();
 		assertEquals(HttpStatus.OK, quarterlyOutput.getStatusCode());
 		assert lineChartItemsQuarterly != null;
@@ -865,8 +866,8 @@ class HelperServiceTest {
 		when(helperServiceMock.getCacheValueForDateRangeIndicatorAndMultipleOrgIdByReflection(anyString(),any(),any(),anyString(),anyList()
 		)).thenReturn(Double.valueOf("7.2"));
 		doNothing().when(helperServiceMock).performCachingForPieChartData(anyList(),anyList(),any(),any(),anyList());
-		doCallRealMethod().when(helperServiceMock).getPieChartDataByPractitionerRoleId(anyString(),anyString(),any(),anyString(),anyString());
-		ResponseEntity<?> output = helperServiceMock.getPieChartDataByPractitionerRoleId("2024-01-01","2024-01-07", filters,testParameters.get("env"),testParameters.get("lga"));
+		doCallRealMethod().when(helperServiceMock).getPieChartDataByPractitionerRoleId(anyString(),anyString(),any(),anyString(),anyString(),false);
+		ResponseEntity<?> output = helperServiceMock.getPieChartDataByPractitionerRoleId("2024-01-01","2024-01-07", filters,testParameters.get("env"),testParameters.get("lga"),false);
 		List<PieChartItemDataCollection> pieChartItemDataCollection  =  (List<PieChartItemDataCollection>) output.getBody();
 		assertEquals(HttpStatus.OK, output.getStatusCode());
 		assert pieChartItemDataCollection != null;
@@ -892,8 +893,8 @@ class HelperServiceTest {
 		PowerMockito.when(notificationDataSourceMock.getCacheValueSumByDateRangeIndicatorAndOrgId(any(),any(),anyString(),anyString())).thenReturn(Double.valueOf("42.0"));
 		Whitebox.setInternalState(NotificationDataSource.class, notificationDataSourceMock);
 		doNothing().when(helperServiceMock).performCachingForTabularData(anyList(),anyList(),any(),any(),anyList());
-		doCallRealMethod().when(helperServiceMock).getTabularDataByPractitionerRoleId(anyString(),anyString(),any(),anyString(),anyString());
-		ResponseEntity<?> output = helperServiceMock.getTabularDataByPractitionerRoleId("2024-01-01","2024-01-07", filters,testParameters.get("env"),testParameters.get("lga"));
+		doCallRealMethod().when(helperServiceMock).getTabularDataByPractitionerRoleId(anyString(),anyString(),any(),anyString(),anyString(),false);
+		ResponseEntity<?> output = helperServiceMock.getTabularDataByPractitionerRoleId("2024-01-01","2024-01-07", filters,testParameters.get("env"),testParameters.get("lga"),false);
 		List<ScoreCardItem> scoreCardItems  =  (List<ScoreCardItem>) output.getBody();
 		assertEquals(HttpStatus.OK, output.getStatusCode());
 		assert scoreCardItems != null;
@@ -904,7 +905,7 @@ class HelperServiceTest {
 		when(helperServiceMock.getTabularItemListFromFile(anyString()
 		)).thenReturn(tabularItemsWithReflection);
 		PowerMockito.when(notificationDataSourceMock.getCacheValueSumByDateRangeIndicatorAndOrgId(any(),any(),anyString(),anyString())).thenReturn(Double.valueOf("22.7"));
-		ResponseEntity<?> result = helperServiceMock.getTabularDataByPractitionerRoleId("2024-01-01","2024-01-07", filters,testParameters.get("env"),testParameters.get("lga"));
+		ResponseEntity<?> result = helperServiceMock.getTabularDataByPractitionerRoleId("2024-01-01","2024-01-07", filters,testParameters.get("env"),testParameters.get("lga"),false);
 		List<ScoreCardItem> scoreCardItemsWithReflection  =  (List<ScoreCardItem>) result.getBody();
 		assertEquals(HttpStatus.OK, result.getStatusCode());
 		assert scoreCardItemsWithReflection != null;


### PR DESCRIPTION
Overview:

- This PR is for anonymizing the data which is being in dashboard. 

- In the application.yaml I have kept two properties minNoisePercentage and maxNoisePercentage. Basically to the original data there will be some random noise added which will be calculated by using random percentage between minNoisePercentage and maxNoisePercentage defined in the application.yaml. 

- For dashboard, scorecard, map and facility summary I am following this method to anonymze the data.
-  Whereas as per register and report page this can't be done because the patient entries with some data has to be shown. In this case what I am doing is that I have added one column anonymization to the async_task_status table which will have yes or no. There will be anonymized entries created in the async_task_status where anonymization will be set to yes.
- Also to view the anonymized data there will be separate user created which will the anonymization attribute which specifies that on login with this user get the anonymized data or else show the actual data.